### PR TITLE
Fix the default export for the Freecurrencyapi class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class FxAPI {
+class Freecurrencyapi {
     baseUrl = 'https://api.freecurrencyapi.com/v1/';
 
     constructor(apiKey = '') {


### PR DESCRIPTION
Changing the "FxAPI" class name to "Freecurrencyapi", so it aligns with the default export